### PR TITLE
The dir_path may need shell escaping if it has spaces, or other bad chars

### DIFF
--- a/plugin/lint.vim
+++ b/plugin/lint.vim
@@ -44,9 +44,10 @@ function! CSSLint()
 endfunction
 
 function! s:lint(cmd)
-  let lint_script = s:dir_path . 'js/' . a:cmd . '/' . a:cmd . '.js '
-  let options_script = s:dir_path . 'js/' . a:cmd . '/options.js ' 
-  let run_script = s:dir_path . 'js/run.js -- ' . a:cmd . ' ' 
+  let esc_path = shellescape(s:dir_path)
+  let lint_script = esc_path . 'js/' . a:cmd . '/' . a:cmd . '.js '
+  let options_script = esc_path . 'js/' . a:cmd . '/options.js '
+  let run_script = esc_path . 'js/run.js -- ' . a:cmd . ' '
   let all_scripts = ' ' . lint_script . options_script . run_script
   let current_file = shellescape(expand('%:p'))
   let output = system(g:d8_command . all_scripts . current_file)


### PR DESCRIPTION
If the `dir_path` isn't escaped, the user receives an error telling them that the path does not exist... For instance, if the file is in the directory `/home/user/My Files/` the `dir_path` will contain the space and an error will appear in the quick fix window complaining about `/home/user/My`

Sorry for the double issue, I've never submitted a pull request before. I hope I did it right this time...
