### PR TITLE
now it works on Windows - determining the plugin's directory changed to be multiplatform

### DIFF
--- a/plugin/lint.vim
+++ b/plugin/lint.vim
@@ -29,7 +29,7 @@ augroup javaScriptLint
   autocmd BufWinLeave * call s:MaybeClearCursorLineColor()
 augroup END
 
-let s:dir_path = expand("<sfile>:s:h") . '/../'
+let s:dir_path = expand("<sfile>:p:h") . '/../'
 
 " Invokes JSHint on the current file
 function! JSHint() 

--- a/plugin/lint.vim
+++ b/plugin/lint.vim
@@ -29,9 +29,7 @@ augroup javaScriptLint
   autocmd BufWinLeave * call s:MaybeClearCursorLineColor()
 augroup END
 
-let s:file_path = expand("<sfile>")
-let s:last_slash = strridx(s:file_path, "/")
-let s:dir_path = strpart(s:file_path, 0, s:last_slash) . '/../'
+let s:dir_path = expand("<sfile>:s:h") . '/../'
 
 " Invokes JSHint on the current file
 function! JSHint() 


### PR DESCRIPTION
The plugin failed to run on Windows because the plugin's root directory was determined using the '/' separator. Changed to a different method which works both on Linux and Windows.
