### PR TITLE
Adding support for skipping jump to first error #8

### DIFF
--- a/plugin/lint.vim
+++ b/plugin/lint.vim
@@ -103,8 +103,13 @@ function! s:lint(cmd)
       silent echon output
     redir END
 
+    let s:quickfix_cmd = 'cfile '
+    if exists('g:lint_skip_jump_to_first_error') && g:lint_skip_jump_to_first_error
+      let s:quickfix_cmd = 'cgetfile '
+    endif
+
     " read in the errors temp file 
-    execute "silent! cfile " . quickfix_tmpfile_name
+    execute "silent! " s:quickfix_cmd . quickfix_tmpfile_name
 
     " change the cursor line to something hard to miss 
     call s:SetCursorLineColor()


### PR DESCRIPTION
Added g:lint_skip_jump_to_first_error which if set to 1 (is set to 0 by
default) skips jumping to the first error location. Fix involves using
:cgetfile instead of :cfile when the option is set.
